### PR TITLE
Support self-highlight when renamed by ACT

### DIFF
--- a/src/views/Combatant.tsx
+++ b/src/views/Combatant.tsx
@@ -21,13 +21,13 @@ function Combatant({ player, index }: CombatantProps) {
   const { name } = player;
   const classes: Argument[] = ['combatant']; // grid classnames
   const { settings } = useStore();
-  const { hlYou, bottomDisp, ticker, tickerAlign, dispMode } = settings;
+  const { hlYou, youName, bottomDisp, ticker, tickerAlign, dispMode } = settings;
 
   // class names related to job
   if (isLimitBreakData(player)) {
     classes.push('job-unknown');
   } else {
-    classes.push({ 'job-self': hlYou && name === 'YOU' }); // highlight
+    classes.push({ 'job-self': hlYou && name === (youName || 'YOU') }); // highlight
     classes.push(`job-${player.job || 'unknown'}`); // job
     classes.push(`jobtype-${player.jobType || 'unknown'}`); // jobtype
   }

--- a/src/views/Combatant.tsx
+++ b/src/views/Combatant.tsx
@@ -27,7 +27,7 @@ function Combatant({ player, index }: CombatantProps) {
   if (isLimitBreakData(player)) {
     classes.push('job-unknown');
   } else {
-    classes.push({ 'job-self': hlYou && name === (youName || 'YOU') }); // highlight
+    classes.push({ 'job-self': hlYou && (name === youName || name === 'YOU')) }); // highlight
     classes.push(`job-${player.job || 'unknown'}`); // job
     classes.push(`jobtype-${player.jobType || 'unknown'}`); // jobtype
   }


### PR DESCRIPTION
The "Data Correction > Default character name" option in ACT lets you rename the default
combatant name from YOU in a way that affects the data received by the overlay plugin; this
should behave correctly when the youName option matches the setting in ACT.