### PR TITLE
Add more theme customization and add Enix theme

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -11,6 +11,7 @@ body,
   width: 100%;
   overflow: hidden;
   position: relative;
+  // background-color: #333;
 }
 
 #root {

--- a/src/App.scss
+++ b/src/App.scss
@@ -11,7 +11,6 @@ body,
   width: 100%;
   overflow: hidden;
   position: relative;
-  // background-color: #333;
 }
 
 #root {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
   }
 
   return (
-    <div className='app'>
+    <div className={`app ${showCombatants ? '' : 'app--minimized'}`}>
       <div className='container'>
         {showCombatants && Boolean(combatant) && combatant.length > 0 && (
           <div className='combatants'>

--- a/src/store/modules/Settings.ts
+++ b/src/store/modules/Settings.ts
@@ -121,7 +121,7 @@ class Settings {
     }
 
     // apply initial theme
-    document.body.setAttribute('data-theme', this.theme.key);
+    document.body.setAttribute('data-theme', this.themeMapKey);
     // apply initial font
     document.documentElement.setAttribute('data-font', this.font);
     // apply initial font weight
@@ -222,7 +222,7 @@ class Settings {
   updateTheme(payload: ThemeMapKey) {
     this.theme = applyDefaultThemeOptions(themes[payload]);
     this.themeMapKey = payload;
-    
+
     if (payload === 'default') {
       document.body.removeAttribute('data-theme');
     } else {

--- a/src/store/modules/Settings.ts
+++ b/src/store/modules/Settings.ts
@@ -15,7 +15,10 @@ import {
   FontFamilyMapKey,
   FontWeightMapKey,
   MAP_FONT_WEIGHT,
+  Theme,
 } from '../../utils/constants';
+import themes from '../../themes';
+import { applyDefaultThemeOptions } from '../../utils/themes';
 
 interface PartialSettings {
   [key: string]: unknown;
@@ -94,7 +97,8 @@ class Settings {
   shortNumber = false;
 
   // general
-  theme: ThemeMapKey = 'default';
+  theme: Theme = applyDefaultThemeOptions(themes.default);
+  themeMapKey: ThemeMapKey = 'default';
   lang: LangMapKey = 'en';
   zoom = 1;
   font: FontFamilyMapKey = 'default';
@@ -117,7 +121,7 @@ class Settings {
     }
 
     // apply initial theme
-    document.body.setAttribute('data-theme', this.theme);
+    document.body.setAttribute('data-theme', this.theme.key);
     // apply initial font
     document.documentElement.setAttribute('data-font', this.font);
     // apply initial font weight
@@ -216,13 +220,15 @@ class Settings {
 
   /* layout */
   updateTheme(payload: ThemeMapKey) {
-    this.theme = payload;
+    this.theme = applyDefaultThemeOptions(themes[payload]);
+    this.themeMapKey = payload;
+    
     if (payload === 'default') {
       document.body.removeAttribute('data-theme');
     } else {
       document.body.setAttribute('data-theme', payload);
     }
-    saveSettings({ theme: payload });
+    saveSettings({ theme: this.theme, themeMapKey: payload });
   }
   updateLang(payload: LangMapKey) {
     this.lang = payload;

--- a/src/themes/barephoenix.scss
+++ b/src/themes/barephoenix.scss
@@ -1,0 +1,87 @@
+/** TODO remove importants */
+body[data-theme=enix] {
+  @mixin enix-container {
+    border: 3px outset #93855A;
+    box-shadow: 0 0 0 2px #333333;
+    border-radius: 8px;
+    background: linear-gradient(#5b626b, #312F31 20px);
+    background-color: #312F31;
+    padding: 8px;
+  }
+
+  .app {
+    .combatants {
+      @include enix-container;
+      padding-bottom: 38px;
+    
+      .combatant {
+        &-content {
+          background-color: transparent !important;
+        }
+    
+        &-name {
+          border-bottom: 4px solid;
+          padding-bottom: 4px;
+          margin-bottom: 4px;
+        }
+    
+        &.jobtype-tank { 
+          & .combatant-name {
+            border-color: var(--color-combatant-bg-tank);
+          }
+        }
+    
+        &.jobtype-dps { 
+          & .combatant-name {
+            border-color: var(--color-combatant-bg-dps);
+          }
+        }
+    
+        &.jobtype-healer { 
+          & .combatant-name {
+            border-color: var(--color-combatant-bg-heal);
+          }
+        }
+
+        &-detail {
+          @include enix-container;
+        }
+      }
+    }
+    
+    .encounter {
+      div {
+        background-color: transparent;
+      }
+
+      &-buttons {
+        .btn:hover {
+          color: #AAAAAA;
+        }
+      }
+    }
+    
+    &:not(.app--minimized) .encounter {
+      position: relative;
+      z-index: 100;
+      top: -38px;
+      padding-top: 4px;
+      border-top: 4px groove #444444;
+      box-shadow: 0px -2px 0px #333333;
+    }
+
+    &.app--minimized .encounter {
+      @include enix-container;
+    }
+
+    .settings {
+      @include enix-container;
+      position: relative;
+      top: 8px;
+    }
+
+    &:not(.app--minimized) .settings {
+      top: -24px;
+    }
+  }
+}

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,9 +1,36 @@
 import './default.scss';
 import './horiz.scss';
 import './ikegami.scss';
+import './barephoenix.scss';
+import { ThemePartial } from '../utils/constants';
 
-export default {
-  default: { text: 'Skyline Overlay' },
-  horiz: { text: 'HORIZOVERLAY' },
-  ikegami: { text: 'ikegami' },
+const themes: {[k: string]: ThemePartial} = {
+  default: { 
+    text: 'Skyline Overlay',
+    key: 'default',
+  },
+  horiz: { 
+    text: 'HORIZOVERLAY',
+    key: 'horiz',
+  },
+  ikegami: { 
+    text: 'ikegami',
+    key: 'ikegami',
+  },
+  enix: { 
+    text: 'Enix',
+    key: 'enix',
+    options: {
+      combatants: {
+        combatant: {
+          hideBottomOnHover: false,
+          detail: {
+            paddingTop: 0.8,
+          }
+        }
+      }
+    }
+  },
 };
+
+export default themes;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -5,21 +5,11 @@ import './barephoenix.scss';
 import { ThemePartial } from '../utils/constants';
 
 const themes: {[k: string]: ThemePartial} = {
-  default: { 
-    text: 'Skyline Overlay',
-    key: 'default',
-  },
-  horiz: { 
-    text: 'HORIZOVERLAY',
-    key: 'horiz',
-  },
-  ikegami: { 
-    text: 'ikegami',
-    key: 'ikegami',
-  },
+  default: { text: 'Skyline Overlay' },
+  horiz: { text: 'HORIZOVERLAY' },
+  ikegami: { text: 'ikegami' },
   enix: { 
     text: 'Enix',
-    key: 'enix',
     options: {
       combatants: {
         combatant: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -79,8 +79,41 @@ export const MAP_LANG = rawLang;
 
 // themes map
 import themes from '../themes';
+import { RecursivePartial } from './type';
 export type ThemeMapKey = keyof typeof themes & string;
 export const MAP_THEMES = themes;
+
+type ThemeOptions = {
+  combatants: {
+    combatant: {
+      hideBottomOnHover: boolean,
+      detail: {
+        paddingTop: number
+      }
+    }
+  }
+}
+export const DefaultThemeOptions: ThemeOptions = {
+  combatants: {
+    combatant: {
+      hideBottomOnHover: true,
+      detail: {
+        paddingTop: 0
+      }
+    }
+  }
+}
+
+export type Theme = {
+  text: string,
+  key: ThemeMapKey,
+  options: ThemeOptions,
+};
+export type ThemePartial = {
+  text: string,
+  key: ThemeMapKey,
+  options?: RecursivePartial<ThemeOptions>,
+};
 
 // font family map
 const fontFamilyMap = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -106,12 +106,10 @@ export const DefaultThemeOptions: ThemeOptions = {
 
 export type Theme = {
   text: string,
-  key: ThemeMapKey,
   options: ThemeOptions,
 };
 export type ThemePartial = {
   text: string,
-  key: ThemeMapKey,
   options?: RecursivePartial<ThemeOptions>,
 };
 

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -1,0 +1,31 @@
+import { ThemePartial, DefaultThemeOptions, Theme } from "./constants";
+
+/**
+ * Applies default options recursively
+ */
+function applyDefaultThemeOptionsInner(options: {[k: string]: any}, defaults: {[k: string]: any}) {
+  Object.keys(defaults).forEach((option) => {
+    if (!(option in options)) {
+      options[option] = defaults[option]
+    } else if (typeof defaults[option] === 'object' && !Array.isArray(defaults[option]) && defaults[option] !== null) {
+      if (option in options) {
+        applyDefaultThemeOptionsInner(options[option], defaults[option])
+      } else {
+        options[option] = defaults[option]
+      }
+    }
+  });
+
+  return options;
+}
+
+/**
+ * Applies all default options to a theme to return a full theme object.
+ */
+export function applyDefaultThemeOptions(theme: ThemePartial) {
+  theme.options = theme.options
+    ? applyDefaultThemeOptionsInner(theme.options, DefaultThemeOptions)
+    : DefaultThemeOptions;
+
+  return theme as Theme;
+}

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -21,3 +21,7 @@ export function isLimitBreakData(
 ): player is LimitBreakData {
   return player.name === 'Limit Break';
 }
+
+export type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};

--- a/src/views/Combatant.tsx
+++ b/src/views/Combatant.tsx
@@ -22,8 +22,7 @@ function Combatant({ player }: CombatantProps) {
   const { name } = player;
   const classes: ClassArray = ['combatant']; // grid classnames
   const { settings } = useStore();
-  const { hlYou, youName, bottomDisp, ticker, tickerAlign, dispMode } =
-    settings;
+  const { hlYou, youName, bottomDisp, ticker, tickerAlign, dispMode, theme } = settings;
 
   // class names related to job
   if (isLimitBreakData(player)) {
@@ -132,7 +131,7 @@ function Combatant({ player }: CombatantProps) {
       {needDetail && (
         <CombatantBottom
           player={player}
-          mode={lockDetail || showDetail ? 'none' : bottomDisp}
+          mode={lockDetail || showDetail && theme.options.combatants.combatant.hideBottomOnHover ? 'none' : bottomDisp}
         />
       )}
 

--- a/src/views/CombatantDetail.tsx
+++ b/src/views/CombatantDetail.tsx
@@ -7,6 +7,7 @@ import { isLimitBreakData } from '../utils/type';
 import { DisplayContentMapKey } from '../utils/constants';
 import { useCallback, useMemo } from 'react';
 import { fmtNumber } from '../utils/formatters';
+import themes from '../themes';
 
 interface CombatantDetailProps {
   player: CombatantData | LimitBreakData;
@@ -16,7 +17,7 @@ interface CombatantDetailProps {
 function CombatantDetail({ player, lockDetail }: CombatantDetailProps) {
   const t = useTranslation();
   const { settings } = useStore();
-  const { dispMode, dispContent, bottomDisp, shortNumber } = settings;
+  const { dispMode, dispContent, bottomDisp, shortNumber, theme } = settings;
 
   // calculate top position according to tickerNum
   let tickerNum = 0;
@@ -27,7 +28,7 @@ function CombatantDetail({ player, lockDetail }: CombatantDetailProps) {
     tickerNum++;
   }
   const baseTop = settings.dispMode === 'dual' ? 0.22 + 0.4 : 0.22 + 0.24; // name + content
-  const topWithTick = (baseTop + tickerNum * 0.04).toFixed(2) + 'rem'; // + ticker
+  const topWithTick = (baseTop + tickerNum * 0.04 + (theme.options.combatants.combatant.detail.paddingTop)).toFixed(2) + 'rem'; // + ticker
 
   const keyNotDisplayed = useCallback(
     (key: DisplayContentMapKey) =>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -222,8 +222,8 @@ function Settings() {
             render: () => (
               <SSelect
                 className='settings-theme'
-                value={settings.theme}
-                onChange={(val) => settings.updateTheme(val)}
+                value={settings.themeMapKey}
+                onChange={(val) => settings.updateTheme(val.toString())}
                 map={MAP_THEMES}
               />
             ),


### PR DESCRIPTION
This PR started as just a simple theme for making this overlay appear as a native dialog. Now, it extends the theming interface a bit to allow more options from individual themes. The goal of this change was to maintain the ease of use for color-changing themes, while also allowing for more complex theme customization. 

The `ThemeOptions` type was added, which defines all available options. Individual `Theme` types within the `themes/index.ts` file are allow to set as many and as few options as the creator wants, using the `ThemePartial` type. Once the theme is ready to be rendered, we will now default all unset options using the `DefaultThemeOptions` constants. These settings can be accessed using the `settings.theme` object from state, and all variables will be accessible on that object (set or not).

```
export const DefaultThemeOptions: ThemeOptions = {
  combatants: {
    combatant: {
      hideBottomOnHover: true,
      detail: {
        paddingTop: 0
      }
    }
  }
}
```

I will note the Enix theme will need a bit more work to get it to look exactly native, but this is a good start.