### PR TITLE
fix: load mock url under different base

### DIFF
--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/utils/mocker.ts
+++ b/src/utils/mocker.ts
@@ -8,7 +8,7 @@ let mockData: any = null;
 export const startMock = async () => {
   let data = cloneDeep(mockData);
   if (!data) {
-    const base = import.meta.env.BASE_URL ?? '/';
+    const base = import.meta.env.BASE_URL ?? '';
     const res = await fetch(`${base}/mock.json`);
     const json = await res.json();
     data = cloneDeep(json);

--- a/src/utils/mocker.ts
+++ b/src/utils/mocker.ts
@@ -9,7 +9,7 @@ export const startMock = async () => {
   let data = cloneDeep(mockData);
   if (!data) {
     const base = import.meta.env.BASE_URL ?? '';
-    const res = await fetch(`${base}/mock.json`);
+    const res = await fetch(`${base.endsWith('/') ? base : base + '/'}mock.json`);
     const json = await res.json();
     data = cloneDeep(json);
     mockData = cloneDeep(json);

--- a/src/utils/mocker.ts
+++ b/src/utils/mocker.ts
@@ -8,7 +8,8 @@ let mockData: any = null;
 export const startMock = async () => {
   let data = cloneDeep(mockData);
   if (!data) {
-    const res = await fetch('/mock.json');
+    const base = import.meta.env.BASE_URL ?? '/';
+    const res = await fetch(`${base}/mock.json`);
     const json = await res.json();
     data = cloneDeep(json);
     mockData = cloneDeep(json);


### PR DESCRIPTION
When build with `VITE_BASE_URL` mock data may fail to load.